### PR TITLE
Integrate billing limits and enforce subscription access

### DIFF
--- a/app/javascript/dashboard/components/app/PaymentPendingBanner.vue
+++ b/app/javascript/dashboard/components/app/PaymentPendingBanner.vue
@@ -67,13 +67,13 @@ export default {
       const account = this.getAccount(this.accountId);
       if (!account) return EMPTY_SUBSCRIPTION_INFO;
 
-      const { custom_attributes: subscription } = account;
-      if (!subscription) return EMPTY_SUBSCRIPTION_INFO;
+      const subscription = account.subscription || {};
+      const status = subscription.status || subscription.subscription_status;
+      const endsOn =
+        subscription.endsOn || subscription.subscription_ends_on || null;
+      const parsedEndsOn = endsOn ? new Date(endsOn) : null;
 
-      const { subscription_status: status, subscription_ends_on: endsOn } =
-        subscription;
-
-      return { status, endsOn: new Date(endsOn) };
+      return { status, endsOn: parsedEndsOn };
     },
   },
 };

--- a/app/javascript/dashboard/helper/routeHelpers.js
+++ b/app/javascript/dashboard/helper/routeHelpers.js
@@ -53,7 +53,64 @@ const validateActiveAccountRoutes = (to, user) => {
   return isAccessible ? null : defaultRedirectPage(to, userPermissions);
 };
 
-export const validateLoggedInRoutes = (to, user) => {
+const BILLING_REQUIRED_ROUTE_PREFIXES = ['captain_'];
+
+const requiresSubscriptionForRoute = routeName =>
+  BILLING_REQUIRED_ROUTE_PREFIXES.some(prefix => routeName?.startsWith(prefix));
+
+const isQuotaUnavailable = limit => {
+  if (!limit) return false;
+
+  const { total_count: totalCount, current_available: currentAvailable } =
+    limit;
+
+  if (typeof totalCount === 'number') {
+    if (totalCount === 0) {
+      return true;
+    }
+
+    if (typeof currentAvailable === 'number') {
+      return currentAvailable <= 0;
+    }
+  }
+
+  return false;
+};
+
+const shouldForceBilling = account => {
+  if (!account) return false;
+
+  const subscription = account.subscription || {};
+  const planName =
+    subscription.plan ||
+    account.plan_name ||
+    account.custom_attributes?.plan_name;
+  const status = subscription.status;
+  const evolutionLimit = account.limits?.evolution?.sessions;
+  const quotaUnavailable = isQuotaUnavailable(evolutionLimit);
+
+  if (!planName || planName === 'Hacker') {
+    return true;
+  }
+
+  const activeStatuses = ['active', 'trialing', 'past_due'];
+
+  if (!status || !activeStatuses.includes(status)) {
+    return true;
+  }
+
+  if (status === 'past_due' && subscription.endsOn) {
+    const renewalDate = new Date(subscription.endsOn);
+    if (Number.isNaN(renewalDate.getTime())) {
+      return false;
+    }
+    return renewalDate < new Date();
+  }
+
+  return quotaUnavailable;
+};
+
+export const validateLoggedInRoutes = (to, user, store) => {
   const currentAccount = getCurrentAccount(user, Number(to.params.accountId));
   // If current account is missing, either user does not have
   // access to the account or the account is deleted, return to login screen
@@ -61,9 +118,26 @@ export const validateLoggedInRoutes = (to, user) => {
     return `app/login`;
   }
 
-  const isCurrentAccountActive = currentAccount.status === 'active';
+  const getAccountFromStore = store?.getters?.['accounts/getAccount'];
+  const accountRecordFromStore =
+    typeof getAccountFromStore === 'function'
+      ? getAccountFromStore(Number(to.params.accountId))
+      : {};
+
+  const hydratedAccount = {
+    ...currentAccount,
+    ...accountRecordFromStore,
+  };
+
+  const isCurrentAccountActive = hydratedAccount.status === 'active';
 
   if (isCurrentAccountActive) {
+    if (
+      requiresSubscriptionForRoute(to.name) &&
+      shouldForceBilling(hydratedAccount)
+    ) {
+      return `accounts/${to.params.accountId}/settings/billing`;
+    }
     return validateActiveAccountRoutes(to, user);
   }
 

--- a/app/javascript/dashboard/i18n/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/en/generalSettings.json
@@ -4,6 +4,7 @@
       "CONVERSATION": "You have exceeded the conversation limit. Hacker plan allows only 500 conversations.",
       "INBOXES": "You have exceeded the inbox limit. Hacker plan only supports website live-chat. Additional inboxes like email, WhatsApp etc. require a paid plan.",
       "AGENTS": "You have exceeded the agent limit. Your plan only allows {allowedAgents} agents.",
+      "EVOLUTION": "You have reached your available Evolution sessions. Upgrade your plan to continue.",
       "NON_ADMIN": "Please contact your administrator to upgrade the plan and continue using all features."
     },
     "TITLE": "Account settings",

--- a/app/javascript/dashboard/routes/dashboard/settings/billing/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/billing/Index.vue
@@ -24,29 +24,19 @@ const {
 
 const uiFlags = useMapGetter('accounts/getUIFlags');
 const store = useStore();
-const customAttributes = computed(() => {
-  return currentAccount.value.custom_attributes || {};
-});
+const subscription = computed(() => currentAccount.value.subscription || {});
 
-/**
- * Computed property for plan name
- * @returns {string|undefined}
- */
 const planName = computed(() => {
-  return customAttributes.value.plan_name;
+  return subscription.value.plan;
 });
 
-/**
- * Computed property for subscribed quantity
- * @returns {number|undefined}
- */
 const subscribedQuantity = computed(() => {
-  return customAttributes.value.subscribed_quantity;
+  return subscription.value.quantity;
 });
 
 const subscriptionRenewsOn = computed(() => {
-  if (!customAttributes.value.subscription_ends_on) return '';
-  const endDate = new Date(customAttributes.value.subscription_ends_on);
+  if (!subscription.value.endsOn) return '';
+  const endDate = new Date(subscription.value.endsOn);
   // return date as 12 Jan, 2034
   return format(endDate, 'dd MMM, yyyy');
 });

--- a/app/javascript/dashboard/routes/dashboard/upgrade/UpgradePage.vue
+++ b/app/javascript/dashboard/routes/dashboard/upgrade/UpgradePage.vue
@@ -28,8 +28,38 @@ const { isAdmin } = useAdmin();
 
 const isOnChatwootCloud = useMapGetter('globalConfig/isOnChatwootCloud');
 
-const testLimit = ({ allowed, consumed }) => {
-  return consumed > allowed;
+const isNumeric = value => typeof value === 'number' && Number.isFinite(value);
+
+const limitExceeded = limit => {
+  if (!limit) return false;
+
+  const {
+    allowed,
+    consumed,
+    total_count: totalCount,
+    current_available: currentAvailable,
+  } = limit;
+
+  if (isNumeric(allowed) && isNumeric(consumed)) {
+    if (allowed === 0) {
+      return consumed > 0;
+    }
+    return consumed >= allowed;
+  }
+
+  if (isNumeric(totalCount)) {
+    if (totalCount === 0) {
+      return true;
+    }
+
+    const remaining = isNumeric(currentAvailable)
+      ? currentAvailable
+      : totalCount - (isNumeric(consumed) ? consumed : 0);
+
+    return remaining <= 0;
+  }
+
+  return false;
 };
 
 const isTrialAccount = computed(() => {
@@ -51,18 +81,21 @@ const limitExceededMessage = computed(() => {
     conversation,
     non_web_inboxes: nonWebInboxes,
     agents,
+    evolution,
   } = account.limits;
 
   let message = '';
 
-  if (testLimit(conversation)) {
+  if (limitExceeded(conversation)) {
     message = t('GENERAL_SETTINGS.LIMIT_MESSAGES.CONVERSATION');
-  } else if (testLimit(nonWebInboxes)) {
+  } else if (limitExceeded(nonWebInboxes)) {
     message = t('GENERAL_SETTINGS.LIMIT_MESSAGES.INBOXES');
-  } else if (testLimit(agents)) {
+  } else if (limitExceeded(agents)) {
     message = t('GENERAL_SETTINGS.LIMIT_MESSAGES.AGENTS', {
       allowedAgents: agents.allowed,
     });
+  } else if (limitExceeded(evolution?.sessions)) {
+    message = t('GENERAL_SETTINGS.LIMIT_MESSAGES.EVOLUTION');
   }
 
   return message;
@@ -76,11 +109,40 @@ const isLimitExceeded = computed(() => {
     conversation,
     non_web_inboxes: nonWebInboxes,
     agents,
+    evolution,
   } = account.limits;
 
   return (
-    testLimit(conversation) || testLimit(nonWebInboxes) || testLimit(agents)
+    limitExceeded(conversation) ||
+    limitExceeded(nonWebInboxes) ||
+    limitExceeded(agents) ||
+    limitExceeded(evolution?.sessions)
   );
+});
+
+const subscription = computed(() => currentAccount.value?.subscription || {});
+
+const subscriptionStatus = computed(() => subscription.value.status || '');
+
+const subscriptionEndsOn = computed(() =>
+  subscription.value.endsOn ? new Date(subscription.value.endsOn) : null
+);
+
+const isSubscriptionExpired = computed(() => {
+  if (!subscriptionStatus.value) {
+    return false;
+  }
+
+  const activeStatuses = ['active', 'trialing', 'past_due'];
+  if (!activeStatuses.includes(subscriptionStatus.value)) {
+    return true;
+  }
+
+  if (subscriptionStatus.value === 'past_due' && subscriptionEndsOn.value) {
+    return subscriptionEndsOn.value < new Date();
+  }
+
+  return false;
 });
 
 const shouldShowUpgradePage = computed(() => {
@@ -88,7 +150,7 @@ const shouldShowUpgradePage = computed(() => {
   if (props.bypassUpgradePage) return false;
   if (!isOnChatwootCloud.value) return false;
   if (isTrialAccount.value) return false;
-  return isLimitExceeded.value;
+  return isLimitExceeded.value || isSubscriptionExpired.value;
 });
 
 const fetchLimits = () => {

--- a/app/javascript/dashboard/routes/index.js
+++ b/app/javascript/dashboard/routes/index.js
@@ -10,8 +10,12 @@ const routes = [...dashboard.routes];
 
 export const router = createRouter({ history: createWebHistory(), routes });
 
-export const validateAuthenticateRoutePermission = (to, next) => {
-  const { isLoggedIn, getCurrentUser: user } = store.getters;
+export const validateAuthenticateRoutePermission = (
+  to,
+  next,
+  appStore = store
+) => {
+  const { isLoggedIn, getCurrentUser: user } = appStore.getters;
 
   if (!isLoggedIn) {
     window.location.assign('/app/login');
@@ -22,7 +26,11 @@ export const validateAuthenticateRoutePermission = (to, next) => {
     return next(frontendURL(`accounts/${user.account_id}/dashboard`));
   }
 
-  const nextRoute = validateLoggedInRoutes(to, store.getters.getCurrentUser);
+  const nextRoute = validateLoggedInRoutes(
+    to,
+    appStore.getters.getCurrentUser,
+    appStore
+  );
   return nextRoute ? next(frontendURL(nextRoute)) : next();
 };
 

--- a/app/javascript/dashboard/store/modules/accounts.js
+++ b/app/javascript/dashboard/store/modules/accounts.js
@@ -11,6 +11,73 @@ const findRecordById = ($state, id) =>
 
 const TRIAL_PERIOD_DAYS = 15;
 
+const mapSubscription = subscription => {
+  if (!subscription) {
+    return {};
+  }
+
+  const {
+    plan = null,
+    status = null,
+    quantity = null,
+    ends_on: endsOn = null,
+  } = subscription;
+
+  return {
+    plan,
+    status,
+    quantity,
+    endsOn,
+  };
+};
+
+const normalizePlan = plan => {
+  if (!plan) {
+    return {};
+  }
+
+  const { name = null, limits = {}, features = [] } = plan;
+
+  return {
+    name,
+    limits,
+    features,
+  };
+};
+
+const buildSubscriptionFromAttributes = customAttributes => {
+  if (!customAttributes) return {};
+
+  const {
+    plan_name: plan,
+    subscription_status: status,
+    subscribed_quantity: quantity,
+    subscription_ends_on: endsOn,
+  } = customAttributes;
+
+  return mapSubscription({ plan, status, quantity, ends_on: endsOn });
+};
+
+const buildAccountRecord = payload => {
+  const subscription = buildSubscriptionFromAttributes(
+    payload.custom_attributes
+  );
+  const plan = normalizePlan(payload.plan);
+
+  const planName = subscription.plan || plan.name;
+
+  const normalizedPlan = {
+    ...plan,
+    name: planName,
+  };
+
+  return {
+    ...payload,
+    subscription,
+    plan: normalizedPlan,
+  };
+};
+
 const state = {
   records: [],
   uiFlags: {
@@ -57,7 +124,8 @@ export const actions = {
     commit(types.default.SET_ACCOUNT_UI_FLAG, { isFetchingItem: true });
     try {
       const response = await AccountAPI.get();
-      commit(types.default.ADD_ACCOUNT, response.data);
+      const accountRecord = buildAccountRecord(response.data);
+      commit(types.default.ADD_ACCOUNT, accountRecord);
       commit(types.default.SET_ACCOUNT_UI_FLAG, {
         isFetchingItem: false,
       });
@@ -143,7 +211,18 @@ export const actions = {
   limits: async ({ commit }) => {
     try {
       const response = await EnterpriseAccountAPI.getLimits();
-      commit(types.default.SET_ACCOUNT_LIMITS, response.data);
+      const { id, limits, subscription, plan } = response.data;
+      const payload = {
+        id,
+        limits,
+        subscription: mapSubscription(subscription),
+      };
+
+      if (plan) {
+        payload.plan = normalizePlan(plan);
+      }
+
+      commit(types.default.SET_ACCOUNT_LIMITS, payload);
     } catch (error) {
       // silent error
     }

--- a/app/javascript/dashboard/store/modules/auth.js
+++ b/app/javascript/dashboard/store/modules/auth.js
@@ -18,6 +18,30 @@ const initialState = {
   },
 };
 
+const buildSubscriptionFromAttributes = customAttributes => {
+  if (!customAttributes) return {};
+
+  const {
+    plan_name: plan,
+    subscription_status: status,
+    subscribed_quantity: quantity,
+    subscription_ends_on: endsOn,
+  } = customAttributes;
+
+  return {
+    plan,
+    status,
+    quantity,
+    endsOn,
+  };
+};
+
+const enhanceAccounts = accounts =>
+  accounts.map(account => ({
+    ...account,
+    subscription: buildSubscriptionFromAttributes(account.custom_attributes),
+  }));
+
 // getters
 export const getters = {
   isLoggedIn($state) {
@@ -105,8 +129,11 @@ export const actions = {
     try {
       const response = await authAPI.validityCheck();
       const currentUser = response.data.payload.data;
-      setUser(currentUser);
-      context.commit(types.SET_CURRENT_USER, currentUser);
+      const accounts = currentUser.accounts || [];
+      const enhancedAccounts = enhanceAccounts(accounts);
+      const enhancedUser = { ...currentUser, accounts: enhancedAccounts };
+      setUser(enhancedUser);
+      context.commit(types.SET_CURRENT_USER, enhancedUser);
     } catch (error) {
       if (error?.response?.status === 401) {
         clearCookiesOnLogout();

--- a/enterprise/app/controllers/enterprise/api/v1/accounts_controller.rb
+++ b/enterprise/app/controllers/enterprise/api/v1/accounts_controller.rb
@@ -13,27 +13,12 @@ class Enterprise::Api::V1::AccountsController < Api::BaseController
   end
 
   def limits
-    limits = if default_plan?(@account)
-               {
-                 'conversation' => {
-                   'allowed' => 500,
-                   'consumed' => conversations_this_month(@account)
-                 },
-                 'non_web_inboxes' => {
-                   'allowed' => 0,
-                   'consumed' => non_web_inboxes(@account)
-                 },
-                 'agents' => {
-                   'allowed' => 2,
-                   'consumed' => agents(@account)
-                 }
-               }
-             else
-               default_limits
-             end
-
-    # include id in response to ensure that the store can be updated on the frontend
-    render json: { id: @account.id, limits: limits }, status: :ok
+    render json: {
+      id: @account.id,
+      limits: serialized_limits,
+      subscription: subscription_payload,
+      plan: plan_payload
+    }, status: :ok
   end
 
   def checkout
@@ -61,15 +46,65 @@ class Enterprise::Api::V1::AccountsController < Api::BaseController
     render json: { error: 'Not found' }, status: :not_found unless ChatwootApp.chatwoot_cloud?
   end
 
-  def default_limits
+  def serialized_limits
+    usage_limits = @account.usage_limits
+
     {
-      'conversation' => {},
-      'non_web_inboxes' => {},
+      'conversation' => conversation_limits,
+      'non_web_inboxes' => non_web_inbox_limits,
       'agents' => {
-        'allowed' => @account.usage_limits[:agents],
+        'allowed' => usage_limits[:agents],
         'consumed' => agents(@account)
       },
-      'captain' => @account.usage_limits[:captain]
+      'captain' => usage_limits[:captain],
+      'evolution' => usage_limits[:evolution]
+    }.compact
+  end
+
+  def conversation_limits
+    allowed = plan_limit_value(:conversation, default_plan?(@account) ? 500 : nil)
+    return {} if allowed.blank?
+
+    {
+      'allowed' => allowed.to_i,
+      'consumed' => conversations_this_month(@account)
+    }
+  end
+
+  def non_web_inbox_limits
+    allowed = plan_limit_value(:non_web_inboxes, default_plan?(@account) ? 0 : nil)
+    return {} if allowed.blank?
+
+    {
+      'allowed' => allowed.to_i,
+      'consumed' => non_web_inboxes(@account)
+    }
+  end
+
+  def plan_limit_value(key, fallback = nil)
+    limits = @account.limits || {}
+    limit_value = limits[key.to_s]
+    return limit_value if limit_value.present?
+
+    fallback
+  end
+
+  def subscription_payload
+    attributes = @account.custom_attributes || {}
+
+    {
+      plan: attributes['plan_name'],
+      status: attributes['subscription_status'],
+      quantity: attributes['subscribed_quantity'],
+      ends_on: attributes['subscription_ends_on']
+    }.compact
+  end
+
+  def plan_payload
+    {
+      name: subscription_payload[:plan],
+      limits: @account.limits || {},
+      features: @account.enabled_features.keys
     }
   end
 

--- a/enterprise/app/models/enterprise/account/plan_usage_and_limits.rb
+++ b/enterprise/app/models/enterprise/account/plan_usage_and_limits.rb
@@ -3,6 +3,8 @@ module Enterprise::Account::PlanUsageAndLimits
   CAPTAIN_DOCUMENTS = 'captain_documents'.freeze
   CAPTAIN_RESPONSES_USAGE = 'captain_responses_usage'.freeze
   CAPTAIN_DOCUMENTS_USAGE = 'captain_documents_usage'.freeze
+  EVOLUTION_SESSIONS = 'evolution_sessions'.freeze
+  EVOLUTION_SESSIONS_USAGE = 'evolution_sessions_usage'.freeze
 
   def usage_limits
     {
@@ -11,6 +13,9 @@ module Enterprise::Account::PlanUsageAndLimits
       captain: {
         documents: get_captain_limits(:documents),
         responses: get_captain_limits(:responses)
+      },
+      evolution: {
+        sessions: get_evolution_limits
       }
     }
   end
@@ -23,6 +28,17 @@ module Enterprise::Account::PlanUsageAndLimits
 
   def reset_response_usage
     custom_attributes[CAPTAIN_RESPONSES_USAGE] = 0
+    save
+  end
+
+  def increment_evolution_usage
+    current_usage = custom_attributes[EVOLUTION_SESSIONS_USAGE].to_i
+    custom_attributes[EVOLUTION_SESSIONS_USAGE] = current_usage + 1
+    save
+  end
+
+  def reset_evolution_usage
+    custom_attributes[EVOLUTION_SESSIONS_USAGE] = 0
     save
   end
 
@@ -50,6 +66,14 @@ module Enterprise::Account::PlanUsageAndLimits
 
   private
 
+  def plan_limits
+    (self[:limits] || {}).with_indifferent_access
+  end
+
+  def evolution_monthly_limit
+    plan_limits[EVOLUTION_SESSIONS] || ChatwootApp.max_limit
+  end
+
   def get_captain_limits(type)
     total_count = captain_monthly_limit[type.to_s].to_i
 
@@ -64,6 +88,18 @@ module Enterprise::Account::PlanUsageAndLimits
     {
       total_count: total_count,
       current_available: (total_count - consumed).clamp(0, total_count),
+      consumed: consumed
+    }
+  end
+
+  def get_evolution_limits
+    total_count = evolution_monthly_limit.to_i
+    consumed = custom_attributes[EVOLUTION_SESSIONS_USAGE].to_i
+    consumed = 0 if consumed.negative?
+
+    {
+      total_count: total_count,
+      current_available: [total_count - consumed, 0].max,
       consumed: consumed
     }
   end
@@ -117,9 +153,12 @@ module Enterprise::Account::PlanUsageAndLimits
       'type' => 'object',
       'properties' => {
         'inboxes' => { 'type': 'number' },
+        'conversation' => { 'type': 'number' },
+        'non_web_inboxes' => { 'type': 'number' },
         'agents' => { 'type': 'number' },
         'captain_responses' => { 'type': 'number' },
-        'captain_documents' => { 'type': 'number' }
+        'captain_documents' => { 'type': 'number' },
+        'evolution_sessions' => { 'type': 'number' }
       },
       'required' => [],
       'additionalProperties' => false

--- a/enterprise/app/services/enterprise/billing/create_stripe_customer_service.rb
+++ b/enterprise/app/services/enterprise/billing/create_stripe_customer_service.rb
@@ -13,15 +13,18 @@ class Enterprise::Billing::CreateStripeCustomerService
         items: [{ price: price_id, quantity: default_quantity }]
       }
     )
-    account.update!(
-      custom_attributes: {
+    account.assign_attributes(
+      custom_attributes: (account.custom_attributes || {}).merge(
         stripe_customer_id: customer_id,
         stripe_price_id: subscription['plan']['id'],
         stripe_product_id: subscription['plan']['product'],
-        plan_name: default_plan['name'],
+        plan_name: default_plan&.[]('name'),
         subscribed_quantity: subscription['quantity']
-      }
+      ),
+      limits: merge_plan_limits(default_plan)
     )
+    account.status = 'active'
+    account.save!
   end
 
   private
@@ -45,12 +48,22 @@ class Enterprise::Billing::CreateStripeCustomerService
 
   def default_plan
     installation_config = InstallationConfig.find_by(name: 'CHATWOOT_CLOUD_PLANS')
-    @default_plan ||= installation_config.value.first
+    plans = installation_config&.value || []
+    @default_plan ||= plans.first
   end
 
   def price_id
     price_ids = default_plan['price_ids']
     price_ids.first
+  end
+
+  def merge_plan_limits(plan)
+    return account.limits if plan.blank?
+
+    existing_limits = (account.limits || {}).with_indifferent_access
+    plan_limits = (plan['limits'] || {}).transform_keys(&:to_s)
+
+    existing_limits.merge(plan_limits).to_h
   end
 
   def existing_subscription?

--- a/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
+++ b/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
@@ -1,33 +1,11 @@
 class Enterprise::Billing::HandleStripeEventService
   CLOUD_PLANS_CONFIG = 'CHATWOOT_CLOUD_PLANS'.freeze
 
-  # Plan hierarchy: Hacker (default) -> Startups -> Business -> Enterprise
-  # Each higher tier includes all features from the lower tiers
-
-  # Basic features available starting with the Startups plan
-  STARTUP_PLAN_FEATURES = %w[
-    inbound_emails
-    help_center
-    campaigns
-    team_management
-    channel_twitter
-    channel_facebook
-    channel_email
-    channel_instagram
-    captain_integration
-  ].freeze
-
-  # Additional features available starting with the Business plan
-  BUSINESS_PLAN_FEATURES = %w[sla custom_roles].freeze
-
-  # Additional features available only in the Enterprise plan
-  ENTERPRISE_PLAN_FEATURES = %w[audit_logs disable_branding].freeze
-
   def perform(event:)
     @event = event
 
     case @event.type
-    when 'customer.subscription.updated'
+    when 'customer.subscription.updated', 'customer.subscription.created'
       process_subscription_updated
     when 'customer.subscription.deleted'
       process_subscription_deleted
@@ -45,83 +23,56 @@ class Enterprise::Billing::HandleStripeEventService
     return if plan.blank? || account.blank?
 
     update_account_attributes(subscription, plan)
-    update_plan_features
-    reset_captain_usage
+    update_plan_features(plan)
+    account.save!
+    reset_metered_usage
   end
 
   def update_account_attributes(subscription, plan)
     # https://stripe.com/docs/api/subscriptions/object
-    account.update(
-      custom_attributes: {
-        stripe_customer_id: subscription.customer,
-        stripe_price_id: subscription['plan']['id'],
-        stripe_product_id: subscription['plan']['product'],
-        plan_name: plan['name'],
-        subscribed_quantity: subscription['quantity'],
-        subscription_status: subscription['status'],
-        subscription_ends_on: Time.zone.at(subscription['current_period_end'])
-      }
+    account.assign_attributes(
+      custom_attributes: (account.custom_attributes || {}).merge(subscription_attributes(subscription, plan)),
+      limits: merged_limits_for(plan)
     )
+    account.status = subscription_active?(subscription) ? 'active' : 'suspended'
   end
 
   def process_subscription_deleted
     # skipping self hosted plan events
     return if account.blank?
 
+    mark_account_as_suspended('canceled')
+    disable_all_premium_features
+    enable_account_manually_managed_features
+    account.save!
     Enterprise::Billing::CreateStripeCustomerService.new(account: account).perform
   end
 
-  def update_plan_features
-    if default_plan?
-      disable_all_premium_features
-    else
-      enable_features_for_current_plan
-    end
+  def update_plan_features(plan)
+    disable_all_premium_features
+    enable_plan_specific_features(plan) unless default_plan?(plan)
 
     # Enable any manually managed features configured in internal_attributes
     enable_account_manually_managed_features
-
-    account.save!
   end
 
   def disable_all_premium_features
-    # Disable all features (for default Hacker plan)
-    account.disable_features(*STARTUP_PLAN_FEATURES)
-    account.disable_features(*BUSINESS_PLAN_FEATURES)
-    account.disable_features(*ENTERPRISE_PLAN_FEATURES)
+    features = premium_features
+    return if features.blank?
+
+    account.disable_features(*features)
   end
 
-  def enable_features_for_current_plan
-    # First disable all premium features to handle downgrades
-    disable_all_premium_features
-
-    # Then enable features based on the current plan
-    enable_plan_specific_features
-  end
-
-  def reset_captain_usage
+  def reset_metered_usage
     account.reset_response_usage
+    account.reset_evolution_usage if account.respond_to?(:reset_evolution_usage)
   end
 
-  def enable_plan_specific_features
-    plan_name = account.custom_attributes['plan_name']
-    return if plan_name.blank?
+  def enable_plan_specific_features(plan)
+    features = plan_features(plan)
+    return if features.blank?
 
-    # Enable features based on plan hierarchy
-    case plan_name
-    when 'Startups'
-      # Startups plan gets the basic features
-      account.enable_features(*STARTUP_PLAN_FEATURES)
-    when 'Business'
-      # Business plan gets Startups features + Business features
-      account.enable_features(*STARTUP_PLAN_FEATURES)
-      account.enable_features(*BUSINESS_PLAN_FEATURES)
-    when 'Enterprise'
-      # Enterprise plan gets all features
-      account.enable_features(*STARTUP_PLAN_FEATURES)
-      account.enable_features(*BUSINESS_PLAN_FEATURES)
-      account.enable_features(*ENTERPRISE_PLAN_FEATURES)
-    end
+    account.enable_features(*features)
   end
 
   def subscription
@@ -133,14 +84,12 @@ class Enterprise::Billing::HandleStripeEventService
   end
 
   def find_plan(plan_id)
-    cloud_plans = InstallationConfig.find_by(name: CLOUD_PLANS_CONFIG)&.value || []
-    cloud_plans.find { |config| config['product_id'].include?(plan_id) }
+    cloud_plans.find { |config| Array(config['product_id']).include?(plan_id) }
   end
 
-  def default_plan?
-    cloud_plans = InstallationConfig.find_by(name: CLOUD_PLANS_CONFIG)&.value || []
-    default_plan = cloud_plans.first || {}
-    account.custom_attributes['plan_name'] == default_plan['name']
+  def default_plan?(plan = nil)
+    plan_name = plan&.[]('name') || account.custom_attributes['plan_name']
+    plan_name.blank? || plan_name == default_plan_config['name']
   end
 
   def enable_account_manually_managed_features
@@ -150,5 +99,80 @@ class Enterprise::Billing::HandleStripeEventService
 
     # Enable each feature
     account.enable_features(*features) if features.present?
+  end
+
+  def subscription_attributes(subscription, plan)
+    {
+      stripe_customer_id: subscription.customer,
+      stripe_price_id: subscription['plan']['id'],
+      stripe_product_id: subscription['plan']['product'],
+      plan_name: plan['name'],
+      subscribed_quantity: subscription['quantity'],
+      subscription_status: subscription['status'],
+      subscription_ends_on: Time.zone.at(subscription['current_period_end'])
+    }
+  end
+
+  def merged_limits_for(plan)
+    return account.limits if plan.blank?
+
+    existing_limits = (account.limits || {}).with_indifferent_access
+    plan_limits = plan_limits_for(plan)
+
+    existing_limits.merge(plan_limits).to_h
+  end
+
+  def plan_limits_for(plan)
+    limits = (plan['limits'] || {}).transform_keys(&:to_s)
+    limits.default = nil
+    limits
+  end
+
+  def subscription_active?(subscription)
+    return false if subscription.blank?
+
+    status = subscription['status']
+    return false if status.blank?
+
+    active_statuses = %w[active trialing past_due]
+    return false unless active_statuses.include?(status)
+
+    period_end = subscription['current_period_end']
+    return true if period_end.blank?
+
+    Time.zone.at(period_end) >= Time.zone.now
+  end
+
+  def premium_features
+    configured = cloud_plans.flat_map { |plan| Array(plan['features']) }
+    return configured.map(&:to_s).uniq if configured.present?
+
+    []
+  end
+
+  def plan_features(plan)
+    features = Array(plan&.[]('features'))
+    return features.map(&:to_s) if features.present?
+
+    []
+  end
+
+  def cloud_plans
+    InstallationConfig.find_by(name: CLOUD_PLANS_CONFIG)&.value || []
+  end
+
+  def default_plan_config
+    cloud_plans.first || {}
+  end
+
+  def mark_account_as_suspended(status)
+    existing_attributes = (account.custom_attributes || {})
+    attrs = existing_attributes.merge(
+      'subscription_status' => status,
+      'subscription_ends_on' => existing_attributes['subscription_ends_on'] || Time.zone.now
+    )
+
+    account.assign_attributes(custom_attributes: attrs)
+    account.status = 'suspended'
   end
 end

--- a/spec/enterprise/controllers/enterprise/api/v1/accounts_controller_spec.rb
+++ b/spec/enterprise/controllers/enterprise/api/v1/accounts_controller_spec.rb
@@ -120,10 +120,47 @@ RSpec.describe 'Enterprise Billing APIs', type: :request do
       end
     end
 
+    let(:default_plan_limits) do
+      {
+        'conversation' => 500,
+        'non_web_inboxes' => 0,
+        'agents' => 2,
+        'captain_documents' => 0,
+        'captain_responses' => 0,
+        'evolution_sessions' => 0
+      }
+    end
+    let(:cloud_plans) do
+      [
+        {
+          'name' => 'Hacker',
+          'product_id' => ['plan_id_hacker'],
+          'price_ids' => ['price_hacker'],
+          'features' => [],
+          'limits' => default_plan_limits
+        },
+        {
+          'name' => 'Startups',
+          'product_id' => ['plan_id_startups'],
+          'price_ids' => ['price_startups'],
+          'features' => ['help_center'],
+          'limits' => {
+            'conversation' => 1000,
+            'non_web_inboxes' => 3,
+            'agents' => 5,
+            'captain_documents' => 10,
+            'captain_responses' => 100,
+            'evolution_sessions' => 20
+          }
+        }
+      ]
+    end
+
     context 'when it is an authenticated user' do
       before do
         InstallationConfig.where(name: 'DEPLOYMENT_ENV').first_or_create(value: 'cloud')
-        InstallationConfig.where(name: 'CHATWOOT_CLOUD_PLANS').first_or_create(value: [{ 'name': 'Hacker' }])
+        InstallationConfig.where(name: 'CHATWOOT_CLOUD_PLANS').first_or_create(value: cloud_plans)
+        account.update!(limits: default_plan_limits)
       end
 
       context 'when it is an agent' do
@@ -148,9 +185,18 @@ RSpec.describe 'Enterprise Billing APIs', type: :request do
               'agents' => {
                 'allowed' => 2,
                 'consumed' => 2
+              },
+              'captain' => {
+                'documents' => { 'total_count' => 0, 'current_available' => 0, 'consumed' => 0 },
+                'responses' => { 'total_count' => 0, 'current_available' => 0, 'consumed' => 0 }
+              },
+              'evolution' => {
+                'sessions' => { 'total_count' => 0, 'current_available' => 0, 'consumed' => 0 }
               }
             }
           )
+          expect(json_response['subscription']).to eq({})
+          expect(json_response['plan']).to eq({ 'name' => nil, 'limits' => default_plan_limits, 'features' => account.enabled_features.keys })
         end
       end
 
@@ -182,7 +228,20 @@ RSpec.describe 'Enterprise Billing APIs', type: :request do
               'agents' => {
                 'allowed' => 2,
                 'consumed' => 2
+              },
+              'captain' => {
+                'documents' => { 'total_count' => 0, 'current_available' => 0, 'consumed' => 0 },
+                'responses' => { 'total_count' => 0, 'current_available' => 0, 'consumed' => 0 }
+              },
+              'evolution' => {
+                'sessions' => { 'total_count' => 0, 'current_available' => 0, 'consumed' => 0 }
               }
+            },
+            'subscription' => { 'plan' => 'Hacker' },
+            'plan' => {
+              'name' => 'Hacker',
+              'limits' => default_plan_limits,
+              'features' => account.enabled_features.keys
             }
           }
 
@@ -192,6 +251,7 @@ RSpec.describe 'Enterprise Billing APIs', type: :request do
 
         it 'returns nil if the plan is not default' do
           account.update!(custom_attributes: { plan_name: 'Startups' })
+          account.update!(limits: cloud_plans.second['limits'])
           get "/enterprise/api/v1/accounts/#{account.id}/limits",
               headers: admin.create_new_auth_token,
               as: :json
@@ -205,10 +265,31 @@ RSpec.describe 'Enterprise Billing APIs', type: :request do
               },
               'conversation' => {},
               'captain' => {
-                'documents' => { 'consumed' => 0, 'current_available' => ChatwootApp.max_limit, 'total_count' => ChatwootApp.max_limit },
-                'responses' => { 'consumed' => 0, 'current_available' => ChatwootApp.max_limit, 'total_count' => ChatwootApp.max_limit }
+                'documents' => {
+                  'total_count' => cloud_plans.second['limits']['captain_documents'],
+                  'current_available' => cloud_plans.second['limits']['captain_documents'],
+                  'consumed' => 0
+                },
+                'responses' => {
+                  'total_count' => cloud_plans.second['limits']['captain_responses'],
+                  'current_available' => cloud_plans.second['limits']['captain_responses'],
+                  'consumed' => 0
+                }
               },
-              'non_web_inboxes' => {}
+              'non_web_inboxes' => {},
+              'evolution' => {
+                'sessions' => {
+                  'total_count' => cloud_plans.second['limits']['evolution_sessions'],
+                  'current_available' => cloud_plans.second['limits']['evolution_sessions'],
+                  'consumed' => 0
+                }
+              }
+            },
+            'subscription' => { 'plan' => 'Startups' },
+            'plan' => {
+              'name' => 'Startups',
+              'limits' => cloud_plans.second['limits'],
+              'features' => account.enabled_features.keys
             }
           }
 
@@ -217,6 +298,7 @@ RSpec.describe 'Enterprise Billing APIs', type: :request do
         end
 
         it 'returns limits if a plan is not configured' do
+          account.update!(limits: {})
           get "/enterprise/api/v1/accounts/#{account.id}/limits",
               headers: admin.create_new_auth_token,
               as: :json
@@ -235,7 +317,20 @@ RSpec.describe 'Enterprise Billing APIs', type: :request do
               'agents' => {
                 'allowed' => 2,
                 'consumed' => 2
+              },
+              'captain' => {
+                'documents' => { 'total_count' => ChatwootApp.max_limit, 'current_available' => ChatwootApp.max_limit, 'consumed' => 0 },
+                'responses' => { 'total_count' => ChatwootApp.max_limit, 'current_available' => ChatwootApp.max_limit, 'consumed' => 0 }
+              },
+              'evolution' => {
+                'sessions' => { 'total_count' => ChatwootApp.max_limit, 'current_available' => ChatwootApp.max_limit, 'consumed' => 0 }
               }
+            },
+            'subscription' => {},
+            'plan' => {
+              'name' => nil,
+              'limits' => {},
+              'features' => account.enabled_features.keys
             }
           }
           expect(response).to have_http_status(:ok)

--- a/spec/enterprise/models/account_spec.rb
+++ b/spec/enterprise/models/account_spec.rb
@@ -142,6 +142,31 @@ RSpec.describe Account, type: :model do
       end
     end
 
+    describe 'when evolution limits are configured' do
+      before do
+        account.update(limits: { evolution_sessions: 10 })
+      end
+
+      it 'returns the total and available sessions' do
+        sessions = account.usage_limits[:evolution][:sessions]
+        expect(sessions[:total_count]).to eq(10)
+        expect(sessions[:current_available]).to eq(10)
+        expect(sessions[:consumed]).to eq(0)
+      end
+
+      it 'tracks consumption correctly' do
+        account.increment_evolution_usage
+        sessions = account.usage_limits[:evolution][:sessions]
+        expect(account.custom_attributes['evolution_sessions_usage']).to eq(1)
+        expect(sessions[:current_available]).to eq(9)
+
+        account.reset_evolution_usage
+        sessions = account.usage_limits[:evolution][:sessions]
+        expect(account.custom_attributes['evolution_sessions_usage']).to eq(0)
+        expect(sessions[:current_available]).to eq(10)
+      end
+    end
+
     describe 'audit logs' do
       it 'returns audit logs' do
         # checking whether associated_audits method is present

--- a/spec/enterprise/services/enterprise/billing/create_stripe_customer_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/create_stripe_customer_service_spec.rb
@@ -13,7 +13,18 @@ describe Enterprise::Billing::CreateStripeCustomerService do
       create(
         :installation_config,
         { name: 'CHATWOOT_CLOUD_PLANS', value: [
-          { 'name' => 'A Plan Name', 'product_id' => ['prod_hacker_random'], 'price_ids' => ['price_hacker_random'] }
+          {
+            'name' => 'A Plan Name',
+            'product_id' => ['prod_hacker_random'],
+            'price_ids' => ['price_hacker_random'],
+            'features' => [],
+            'limits' => {
+              'agents' => 2,
+              'conversation' => 500,
+              'non_web_inboxes' => 0,
+              'evolution_sessions' => 0
+            }
+          }
         ] }
       )
     end
@@ -38,7 +49,9 @@ describe Enterprise::Billing::CreateStripeCustomerService do
         .to have_received(:create)
         .with({ customer: 'cus_random_number', items: [{ price: 'price_hacker_random', quantity: 2 }] })
 
-      expect(account.reload.custom_attributes).to eq(
+      reloaded_account = account.reload
+
+      expect(reloaded_account.custom_attributes).to eq(
         {
           stripe_customer_id: 'cus_random_number',
           stripe_price_id: 'price_random_number',
@@ -47,6 +60,13 @@ describe Enterprise::Billing::CreateStripeCustomerService do
           plan_name: 'A Plan Name'
         }.with_indifferent_access
       )
+      expect(reloaded_account.limits).to include(
+        'agents' => 2,
+        'conversation' => 500,
+        'non_web_inboxes' => 0,
+        'evolution_sessions' => 0
+      )
+      expect(reloaded_account.status).to eq('active')
     end
 
     it 'calls stripe methods to create a customer and updates the account' do
@@ -69,7 +89,9 @@ describe Enterprise::Billing::CreateStripeCustomerService do
         .to have_received(:create)
         .with({ customer: customer.id, items: [{ price: 'price_hacker_random', quantity: 2 }] })
 
-      expect(account.reload.custom_attributes).to eq(
+      reloaded_account = account.reload
+
+      expect(reloaded_account.custom_attributes).to eq(
         {
           stripe_customer_id: customer.id,
           stripe_price_id: 'price_random_number',
@@ -78,6 +100,13 @@ describe Enterprise::Billing::CreateStripeCustomerService do
           plan_name: 'A Plan Name'
         }.with_indifferent_access
       )
+      expect(reloaded_account.limits).to include(
+        'agents' => 2,
+        'conversation' => 500,
+        'non_web_inboxes' => 0,
+        'evolution_sessions' => 0
+      )
+      expect(reloaded_account.status).to eq('active')
     end
   end
 
@@ -86,7 +115,18 @@ describe Enterprise::Billing::CreateStripeCustomerService do
       create(
         :installation_config,
         { name: 'CHATWOOT_CLOUD_PLANS', value: [
-          { 'name' => 'A Plan Name', 'product_id' => ['prod_hacker_random'], 'price_ids' => ['price_hacker_random'] }
+          {
+            'name' => 'A Plan Name',
+            'product_id' => ['prod_hacker_random'],
+            'price_ids' => ['price_hacker_random'],
+            'features' => [],
+            'limits' => {
+              'agents' => 2,
+              'conversation' => 500,
+              'non_web_inboxes' => 0,
+              'evolution_sessions' => 0
+            }
+          }
         ] }
       )
     end

--- a/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
+++ b/spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb
@@ -7,17 +7,76 @@ describe Enterprise::Billing::HandleStripeEventService do
   let(:data) { double }
   let(:subscription) { double }
   let!(:account) { create(:account, custom_attributes: { stripe_customer_id: 'cus_123' }) }
+  let(:default_plan_features) { [] }
+  let(:startup_features) do
+    %w[
+      inbound_emails
+      help_center
+      campaigns
+      team_management
+      channel_twitter
+      channel_facebook
+      channel_email
+      channel_instagram
+      captain_integration
+    ]
+  end
+  let(:business_features) { %w[sla custom_roles] }
+  let(:enterprise_features) { %w[audit_logs disable_branding] }
+  let(:plan_limits) do
+    {
+      'Hacker' => {
+        'conversation' => 500,
+        'non_web_inboxes' => 0,
+        'agents' => 2,
+        'captain_responses' => 0,
+        'captain_documents' => 0,
+        'evolution_sessions' => 0
+      },
+      'Startups' => {
+        'conversation' => 1_000,
+        'non_web_inboxes' => 3,
+        'agents' => 5,
+        'captain_responses' => 100,
+        'captain_documents' => 10,
+        'evolution_sessions' => 20
+      },
+      'Business' => {
+        'conversation' => 5_000,
+        'non_web_inboxes' => 10,
+        'agents' => 15,
+        'captain_responses' => 500,
+        'captain_documents' => 50,
+        'evolution_sessions' => 100
+      },
+      'Enterprise' => {
+        'conversation' => 10_000,
+        'non_web_inboxes' => 20,
+        'agents' => 30,
+        'captain_responses' => 2_000,
+        'captain_documents' => 200,
+        'evolution_sessions' => 500
+      }
+    }
+  end
+  let(:cloud_plans) do
+    [
+      { 'name' => 'Hacker', 'product_id' => ['plan_id_hacker'], 'price_ids' => ['price_hacker'], 'features' => default_plan_features,
+        'limits' => plan_limits['Hacker'] },
+      { 'name' => 'Startups', 'product_id' => ['plan_id_startups'], 'price_ids' => ['price_startups'], 'features' => startup_features,
+        'limits' => plan_limits['Startups'] },
+      { 'name' => 'Business', 'product_id' => ['plan_id_business'], 'price_ids' => ['price_business'], 'features' => business_features,
+        'limits' => plan_limits['Business'] },
+      { 'name' => 'Enterprise', 'product_id' => ['plan_id_enterprise'], 'price_ids' => ['price_enterprise'],
+        'features' => enterprise_features, 'limits' => plan_limits['Enterprise'] }
+    ]
+  end
 
   before do
     # Create cloud plans configuration
     create(:installation_config, {
              name: 'CHATWOOT_CLOUD_PLANS',
-             value: [
-               { 'name' => 'Hacker', 'product_id' => ['plan_id_hacker'], 'price_ids' => ['price_hacker'] },
-               { 'name' => 'Startups', 'product_id' => ['plan_id_startups'], 'price_ids' => ['price_startups'] },
-               { 'name' => 'Business', 'product_id' => ['plan_id_business'], 'price_ids' => ['price_business'] },
-               { 'name' => 'Enterprise', 'product_id' => ['plan_id_enterprise'], 'price_ids' => ['price_enterprise'] }
-             ]
+             value: cloud_plans
            })
     # Setup common subscription mocks
     allow(event).to receive(:data).and_return(data)
@@ -38,18 +97,20 @@ describe Enterprise::Billing::HandleStripeEventService do
       stripe_event_service.new.perform(event: event)
 
       # Verify account attributes were updated
-      expect(account.reload.custom_attributes).to include(
+      reloaded_account = account.reload
+      expect(reloaded_account.custom_attributes).to include(
         'plan_name' => 'Hacker',
         'stripe_product_id' => 'plan_id_hacker',
         'subscription_status' => 'active'
       )
 
+      expect(reloaded_account.limits).to include(plan_limits['Hacker'])
+      expect(reloaded_account.status).to eq('active')
+
       # Verify premium features are disabled for default plan
-      expect(account).not_to be_feature_enabled('channel_email')
-      expect(account).not_to be_feature_enabled('help_center')
-      expect(account).not_to be_feature_enabled('sla')
-      expect(account).not_to be_feature_enabled('custom_roles')
-      expect(account).not_to be_feature_enabled('audit_logs')
+      (startup_features + business_features + enterprise_features).each do |feature|
+        expect(reloaded_account).not_to be_feature_enabled(feature)
+      end
     end
 
     it 'resets captain usage on subscription update' do
@@ -65,7 +126,8 @@ describe Enterprise::Billing::HandleStripeEventService do
 
       # Verify usage was reset
       expect(account.reload.custom_attributes['captain_responses_usage']).to eq(0)
-    end
+      expect(account.status).to eq('active')
+  end
   end
 
   describe 'subscription deletion handling' do
@@ -84,7 +146,8 @@ describe Enterprise::Billing::HandleStripeEventService do
       expect(Enterprise::Billing::CreateStripeCustomerService).to have_received(:new)
         .with(account: account)
       expect(customer_service).to have_received(:perform)
-    end
+      expect(account.status).to eq('suspended')
+  end
   end
 
   describe 'plan-specific feature management' do
@@ -94,23 +157,19 @@ describe Enterprise::Billing::HandleStripeEventService do
                                            .and_return({ 'id' => 'test', 'product' => 'plan_id_hacker', 'name' => 'Hacker' })
 
         # Enable features first
-        described_class::STARTUP_PLAN_FEATURES.each do |feature|
+        (startup_features + business_features + enterprise_features).each do |feature|
           account.enable_features(feature)
         end
-        account.enable_features(*described_class::BUSINESS_PLAN_FEATURES)
-        account.enable_features(*described_class::ENTERPRISE_PLAN_FEATURES)
         account.save!
 
         account.reload
-        expect(account).to be_feature_enabled(described_class::STARTUP_PLAN_FEATURES.first)
+        expect(account).to be_feature_enabled(startup_features.first)
 
         stripe_event_service.new.perform(event: event)
 
         account.reload
 
-        all_features = described_class::STARTUP_PLAN_FEATURES +
-                       described_class::BUSINESS_PLAN_FEATURES +
-                       described_class::ENTERPRISE_PLAN_FEATURES
+        all_features = startup_features + business_features + enterprise_features
 
         all_features.each do |feature|
           expect(account).not_to be_feature_enabled(feature)
@@ -127,16 +186,16 @@ describe Enterprise::Billing::HandleStripeEventService do
 
         # Verify basic (Startups) features are enabled
         account.reload
-        described_class::STARTUP_PLAN_FEATURES.each do |feature|
+        startup_features.each do |feature|
           expect(account).to be_feature_enabled(feature)
         end
 
         # But business and enterprise features should be disabled
-        described_class::BUSINESS_PLAN_FEATURES.each do |feature|
+        business_features.each do |feature|
           expect(account).not_to be_feature_enabled(feature)
         end
 
-        described_class::ENTERPRISE_PLAN_FEATURES.each do |feature|
+        enterprise_features.each do |feature|
           expect(account).not_to be_feature_enabled(feature)
         end
       end
@@ -150,15 +209,15 @@ describe Enterprise::Billing::HandleStripeEventService do
         stripe_event_service.new.perform(event: event)
 
         account.reload
-        described_class::STARTUP_PLAN_FEATURES.each do |feature|
+        startup_features.each do |feature|
           expect(account).to be_feature_enabled(feature)
         end
 
-        described_class::BUSINESS_PLAN_FEATURES.each do |feature|
+        business_features.each do |feature|
           expect(account).to be_feature_enabled(feature)
         end
 
-        described_class::ENTERPRISE_PLAN_FEATURES.each do |feature|
+        enterprise_features.each do |feature|
           expect(account).not_to be_feature_enabled(feature)
         end
       end
@@ -172,15 +231,15 @@ describe Enterprise::Billing::HandleStripeEventService do
         stripe_event_service.new.perform(event: event)
 
         account.reload
-        described_class::STARTUP_PLAN_FEATURES.each do |feature|
+        startup_features.each do |feature|
           expect(account).to be_feature_enabled(feature)
         end
 
-        described_class::BUSINESS_PLAN_FEATURES.each do |feature|
+        business_features.each do |feature|
           expect(account).to be_feature_enabled(feature)
         end
 
-        described_class::ENTERPRISE_PLAN_FEATURES.each do |feature|
+        enterprise_features.each do |feature|
           expect(account).to be_feature_enabled(feature)
         end
       end

--- a/spec/helpers/billing_helper_spec.rb
+++ b/spec/helpers/billing_helper_spec.rb
@@ -12,12 +12,26 @@ RSpec.describe BillingHelper do
                  {
                    'name' => 'Hacker',
                    'product_id' => ['plan_id'],
-                   'price_ids' => ['price_1']
+                   'price_ids' => ['price_1'],
+                   'features' => [],
+                   'limits' => {
+                     'conversation' => 500,
+                     'non_web_inboxes' => 0,
+                     'agents' => 2,
+                     'evolution_sessions' => 0
+                   }
                  },
                  {
                    'name' => 'Startups',
                    'product_id' => ['plan_id_2'],
-                   'price_ids' => ['price_2']
+                   'price_ids' => ['price_2'],
+                   'features' => ['help_center'],
+                   'limits' => {
+                     'conversation' => 1000,
+                     'non_web_inboxes' => 3,
+                     'agents' => 5,
+                     'evolution_sessions' => 20
+                   }
                  }
                ]
              })


### PR DESCRIPTION
## Summary
- persist plan limits including Evolution sessions on accounts and expose them via the enterprise limits API
- update billing services to sync Stripe subscriptions, feature flags, and account status/limits while resetting usage meters
- surface subscription/limit state in the dashboard store, guards, and upgrade flow with new messaging for Evolution usage and billing access

## Testing
- `bundle exec rake spec SPEC='spec/enterprise/services/enterprise/billing/handle_stripe_event_service_spec.rb spec/enterprise/services/enterprise/billing/create_stripe_customer_service_spec.rb spec/enterprise/controllers/enterprise/api/v1/accounts_controller_spec.rb spec/enterprise/models/account_spec.rb spec/helpers/billing_helper_spec.rb'` *(fails: Ruby 3.2.3 available but Gemfile requires 3.4.4)*

------
https://chatgpt.com/codex/tasks/task_e_68cde21447548325800cba2272cbb0be