### PR TITLE
Add premium wood store landing page (/loja)

### DIFF
--- a/app/controllers/public/store_controller.rb
+++ b/app/controllers/public/store_controller.rb
@@ -1,0 +1,5 @@
+class Public::StoreController < PublicController
+  layout 'store'
+
+  def show; end
+end

--- a/app/views/layouts/store.html.erb
+++ b/app/views/layouts/store.html.erb
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="<%= I18n.locale %>">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><%= t('public_store.meta.title') %></title>
+    <meta name="description" content="<%= t('public_store.meta.description') %>">
+    <%= csrf_meta_tags %>
+    <%= vite_client_tag %>
+    <%= vite_javascript_tag 'portal' %>
+    <script>
+      window.portalConfig = {
+        customDomain: '',
+        hostURL: '',
+        isPlainLayoutEnabled: 'true'
+      };
+    </script>
+  </head>
+  <body class="bg-slate-950 text-slate-100 antialiased">
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/public/store/show.html.erb
+++ b/app/views/public/store/show.html.erb
@@ -1,0 +1,165 @@
+<% highlights = I18n.t('public_store.highlights.items') %>
+<% products = I18n.t('public_store.products.items') %>
+<% services = I18n.t('public_store.services.items') %>
+<% testimonials = I18n.t('public_store.testimonials.items') %>
+
+<div class="min-h-screen bg-slate-950">
+  <header class="border-b border-slate-800/80">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-6">
+      <div class="flex flex-col">
+        <span class="text-xs font-semibold uppercase tracking-[0.3em] text-amber-400"><%= t('public_store.brand.kicker') %></span>
+        <span class="text-lg font-semibold text-slate-100"><%= t('public_store.brand.name') %></span>
+      </div>
+      <nav class="hidden gap-8 text-sm text-slate-300 md:flex">
+        <a class="transition hover:text-amber-300" href="#colecao"><%= t('public_store.nav.collection') %></a>
+        <a class="transition hover:text-amber-300" href="#atelier"><%= t('public_store.nav.atelier') %></a>
+        <a class="transition hover:text-amber-300" href="#contato"><%= t('public_store.nav.contact') %></a>
+      </nav>
+      <a class="hidden rounded-full border border-amber-300/60 px-5 py-2 text-sm font-semibold text-amber-200 transition hover:border-amber-300 hover:text-amber-100 md:inline-flex" href="#contato">
+        <%= t('public_store.nav.cta') %>
+      </a>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-6xl px-6 py-16">
+    <section class="grid gap-10 md:grid-cols-[1.1fr_0.9fr] md:items-center">
+      <div>
+        <p class="text-sm font-semibold uppercase tracking-[0.2em] text-amber-400"><%= t('public_store.hero.kicker') %></p>
+        <h1 class="mt-4 text-4xl font-semibold leading-tight text-slate-50 md:text-5xl"><%= t('public_store.hero.title') %></h1>
+        <p class="mt-6 text-lg text-slate-300"><%= t('public_store.hero.subtitle') %></p>
+        <div class="mt-8 flex flex-wrap gap-4">
+          <a class="rounded-full bg-amber-400 px-6 py-3 text-sm font-semibold text-slate-950 transition hover:bg-amber-300" href="#contato">
+            <%= t('public_store.hero.primary_action') %>
+          </a>
+          <a class="rounded-full border border-slate-700 px-6 py-3 text-sm font-semibold text-slate-200 transition hover:border-slate-500" href="#colecao">
+            <%= t('public_store.hero.secondary_action') %>
+          </a>
+        </div>
+        <div class="mt-10 flex flex-wrap gap-6 text-sm text-slate-400">
+          <div class="flex flex-col">
+            <span class="text-base font-semibold text-slate-100"><%= t('public_store.hero.metrics.first.value') %></span>
+            <span><%= t('public_store.hero.metrics.first.label') %></span>
+          </div>
+          <div class="flex flex-col">
+            <span class="text-base font-semibold text-slate-100"><%= t('public_store.hero.metrics.second.value') %></span>
+            <span><%= t('public_store.hero.metrics.second.label') %></span>
+          </div>
+          <div class="flex flex-col">
+            <span class="text-base font-semibold text-slate-100"><%= t('public_store.hero.metrics.third.value') %></span>
+            <span><%= t('public_store.hero.metrics.third.label') %></span>
+          </div>
+        </div>
+      </div>
+      <div class="rounded-3xl border border-slate-800 bg-gradient-to-br from-slate-900 via-slate-900 to-amber-900/30 p-8 shadow-2xl">
+        <div class="space-y-6">
+          <div>
+            <span class="text-xs font-semibold uppercase tracking-[0.2em] text-amber-300"><%= t('public_store.hero.card.kicker') %></span>
+            <h2 class="mt-3 text-2xl font-semibold text-slate-50"><%= t('public_store.hero.card.title') %></h2>
+            <p class="mt-3 text-sm text-slate-300"><%= t('public_store.hero.card.description') %></p>
+          </div>
+          <div class="grid gap-4">
+            <% highlights.each do |highlight| %>
+              <div class="rounded-2xl border border-slate-800/80 bg-slate-950/70 p-4">
+                <p class="text-sm font-semibold text-amber-200"><%= highlight['title'] %></p>
+                <p class="mt-2 text-sm text-slate-300"><%= highlight['description'] %></p>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="colecao" class="mt-20">
+      <div class="flex flex-col justify-between gap-6 md:flex-row md:items-end">
+        <div>
+          <p class="text-sm font-semibold uppercase tracking-[0.2em] text-amber-400"><%= t('public_store.products.kicker') %></p>
+          <h2 class="mt-3 text-3xl font-semibold text-slate-50"><%= t('public_store.products.title') %></h2>
+          <p class="mt-4 max-w-2xl text-base text-slate-300"><%= t('public_store.products.subtitle') %></p>
+        </div>
+        <span class="text-sm text-slate-400"><%= t('public_store.products.note') %></span>
+      </div>
+      <div class="mt-10 grid gap-6 md:grid-cols-2">
+        <% products.each do |product| %>
+          <div class="flex h-full flex-col justify-between rounded-3xl border border-slate-800 bg-slate-950/70 p-6">
+            <div>
+              <div class="flex items-center justify-between">
+                <p class="text-lg font-semibold text-slate-100"><%= product['name'] %></p>
+                <span class="rounded-full bg-amber-400/10 px-3 py-1 text-xs font-semibold text-amber-300"><%= product['tag'] %></span>
+              </div>
+              <p class="mt-3 text-sm text-slate-300"><%= product['description'] %></p>
+            </div>
+            <div class="mt-8 flex items-center justify-between">
+              <span class="text-xl font-semibold text-amber-200"><%= product['price'] %></span>
+              <span class="text-xs text-slate-500"><%= product['availability'] %></span>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </section>
+
+    <section id="atelier" class="mt-20 grid gap-10 md:grid-cols-[0.9fr_1.1fr]">
+      <div class="rounded-3xl border border-slate-800 bg-slate-950/80 p-8">
+        <p class="text-sm font-semibold uppercase tracking-[0.2em] text-amber-400"><%= t('public_store.services.kicker') %></p>
+        <h2 class="mt-3 text-3xl font-semibold text-slate-50"><%= t('public_store.services.title') %></h2>
+        <p class="mt-4 text-base text-slate-300"><%= t('public_store.services.subtitle') %></p>
+        <div class="mt-8 space-y-4">
+          <% services.each do |service| %>
+            <div class="rounded-2xl border border-slate-800/80 bg-slate-950/70 p-5">
+              <p class="text-sm font-semibold text-amber-200"><%= service['title'] %></p>
+              <p class="mt-2 text-sm text-slate-300"><%= service['description'] %></p>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <div class="space-y-6">
+        <div class="rounded-3xl border border-amber-300/20 bg-amber-300/5 p-8">
+          <p class="text-sm font-semibold uppercase tracking-[0.2em] text-amber-300"><%= t('public_store.atelier.kicker') %></p>
+          <h3 class="mt-3 text-2xl font-semibold text-slate-100"><%= t('public_store.atelier.title') %></h3>
+          <p class="mt-4 text-base text-slate-300"><%= t('public_store.atelier.description') %></p>
+          <div class="mt-6 flex flex-wrap gap-4">
+            <% testimonials.each do |testimonial| %>
+              <div class="rounded-2xl border border-slate-800 bg-slate-950/60 p-4">
+                <p class="text-sm text-slate-200">“<%= testimonial['quote'] %>”</p>
+                <p class="mt-3 text-xs text-amber-200"><%= testimonial['author'] %></p>
+              </div>
+            <% end %>
+          </div>
+        </div>
+        <div class="rounded-3xl border border-slate-800 bg-slate-950/70 p-6">
+          <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p class="text-sm font-semibold text-slate-100"><%= t('public_store.curation.title') %></p>
+              <p class="mt-2 text-sm text-slate-300"><%= t('public_store.curation.description') %></p>
+            </div>
+            <span class="rounded-full border border-amber-300/40 px-4 py-2 text-xs font-semibold text-amber-200"><%= t('public_store.curation.tag') %></span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="contato" class="mt-20 rounded-3xl border border-amber-300/20 bg-gradient-to-br from-amber-400/10 via-slate-950 to-slate-950 p-10">
+      <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p class="text-sm font-semibold uppercase tracking-[0.2em] text-amber-300"><%= t('public_store.cta.kicker') %></p>
+          <h2 class="mt-3 text-3xl font-semibold text-slate-50"><%= t('public_store.cta.title') %></h2>
+          <p class="mt-4 text-base text-slate-300"><%= t('public_store.cta.subtitle') %></p>
+        </div>
+        <div class="flex flex-wrap gap-4">
+          <a class="rounded-full bg-amber-300 px-6 py-3 text-sm font-semibold text-slate-950 transition hover:bg-amber-200" href="mailto:atelier@madeiranobre.com">
+            <%= t('public_store.cta.primary_action') %>
+          </a>
+          <a class="rounded-full border border-slate-700 px-6 py-3 text-sm font-semibold text-slate-200 transition hover:border-slate-500" href="tel:+551130000000">
+            <%= t('public_store.cta.secondary_action') %>
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-slate-800/80">
+    <div class="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-8 text-sm text-slate-400 md:flex-row md:items-center md:justify-between">
+      <span><%= t('public_store.footer.note') %></span>
+      <span><%= t('public_store.footer.address') %></span>
+    </div>
+  </footer>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,108 @@
 
 en:
   hello: 'Hello world'
+  public_store:
+    meta:
+      title: 'Atelier Madeira Nobre | Loja online'
+      description: 'Loja online de artigos de madeira premium, com peças autorais, acabamento artesanal e produção sob encomenda.'
+    brand:
+      kicker: 'Atelier'
+      name: 'Madeira Nobre'
+    nav:
+      collection: 'Coleção'
+      atelier: 'Atelier'
+      contact: 'Contato'
+      cta: 'Atendimento exclusivo'
+    hero:
+      kicker: 'Alta marcenaria contemporânea'
+      title: 'Peças de madeira sob medida para cozinhas e salas de alto padrão'
+      subtitle: 'Tábuas para carne, mesas e acessórios feitos com madeiras nobres, design autoral e acabamento impecável.'
+      primary_action: 'Agendar consultoria'
+      secondary_action: 'Ver coleção'
+      metrics:
+        first:
+          value: '12 anos'
+          label: 'de atelier autoral'
+        second:
+          value: '48h'
+          label: 'para orçamento inicial'
+        third:
+          value: '100%'
+          label: 'madeira certificada'
+      card:
+        kicker: 'Detalhes que elevam'
+        title: 'Cada peça recebe atenção de boutique'
+        description: 'Selecionamos tábuas únicas, cuidamos da secagem e finalizamos manualmente com óleos naturais.'
+    highlights:
+      items:
+        - title: 'Seleção de madeiras raras'
+          description: 'Cumaru, nogueira, jequitibá e ipê escolhidos por desenho e estabilidade.'
+        - title: 'Acabamento de chef'
+          description: 'Superfícies seladas para contato com alimentos e toque acetinado.'
+        - title: 'Design exclusivo'
+          description: 'Modelos que valorizam veios naturais e ressaltam o espaço gourmet.'
+    products:
+      kicker: 'Coleção premium'
+      title: 'Peças icônicas para casas sofisticadas'
+      subtitle: 'Um catálogo enxuto, pensado para transformar experiências de cozinha e convívio.'
+      note: 'Envio nacional com seguro total'
+      items:
+        - name: 'Tábua Ares de Nogueira'
+          description: 'Tábua para carne com 45 cm, canaleta profunda e pés antiderrapantes.'
+          price: 'R$ 890'
+          tag: 'Mais vendido'
+          availability: 'Pronta entrega'
+        - name: 'Mesa Luar em Jequitibá'
+          description: 'Mesa de jantar para 8 lugares com tampo maciço e borda orgânica.'
+          price: 'R$ 18.900'
+          tag: 'Sob encomenda'
+          availability: 'Entrega em 45 dias'
+        - name: 'Bandeja Serena'
+          description: 'Bandeja de serviço com 60 cm, alças embutidas e acabamento fosco.'
+          price: 'R$ 1.450'
+          tag: 'Edição limitada'
+          availability: '5 unidades'
+        - name: 'Bloco de Facas Atlântida'
+          description: 'Bloco de facas modular com compartimentos ocultos e base em latão.'
+          price: 'R$ 2.350'
+          tag: 'Novo'
+          availability: 'Pronta entrega'
+    services:
+      kicker: 'Curadoria personalizada'
+      title: 'Experiência sob medida para projetos exclusivos'
+      subtitle: 'Atendemos arquitetos, chefs e proprietários que buscam peças de personalidade.'
+      items:
+        - title: 'Consultoria de materiais'
+          description: 'Recomendamos madeiras e acabamentos compatíveis com o ambiente e uso.'
+        - title: 'Prototipagem refinada'
+          description: 'Maquetes e amostras com veios reais para validação estética.'
+        - title: 'Instalação assistida'
+          description: 'Equipe técnica para entrega, montagem e ajustes finais.'
+    atelier:
+      kicker: 'Nossa assinatura'
+      title: 'Atelier com produção artesanal e tecnologia de precisão'
+      description: 'Unimos técnicas de marcenaria clássica com ferramentas de alta precisão para garantir peças únicas.'
+    testimonials:
+      items:
+        - quote: 'A tábua virou peça central do espaço gourmet. O acabamento é impecável.'
+          author: 'Camila R., São Paulo'
+        - quote: 'A mesa trouxe sofisticação e conforto. Atendimento impecável do início ao fim.'
+          author: 'Henrique M., Brasília'
+        - quote: 'Design atemporal e presença marcante. Uma verdadeira obra de arte.'
+          author: 'Lívia A., Florianópolis'
+    curation:
+      title: 'Produção limitada para manter a exclusividade'
+      description: 'Cada lote é numerado e acompanhado de certificado de origem.'
+      tag: 'Série numerada'
+    cta:
+      kicker: 'Vamos criar sua peça'
+      title: 'Agende uma conversa com nosso atelier'
+      subtitle: 'Compartilhe referências, medidas e expectativas. Retornamos com um roteiro personalizado.'
+      primary_action: 'Falar com o atelier'
+      secondary_action: 'Ligar agora'
+    footer:
+      note: 'Atelier Madeira Nobre · Peças autorais em madeira maciça'
+      address: 'Atendimento por agendamento · Brasil'
   inbox:
     reauthorization:
       success: 'Channel reauthorized successfully'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -515,6 +515,7 @@ Rails.application.routes.draw do
   get 'webhooks/whatsapp/:phone_number', to: 'webhooks/whatsapp#verify'
   post 'webhooks/whatsapp/:phone_number', to: 'webhooks/whatsapp#process_payload'
   get 'webhooks/instagram', to: 'webhooks/instagram#verify'
+  get 'loja', to: 'public/store#show'
   post 'webhooks/instagram', to: 'webhooks/instagram#events'
 
   namespace :twitter do


### PR DESCRIPTION
### Motivation
- Provide a simple, high-end storefront landing page for a boutique wood products atelier (premium cutting boards, tables, accessories) accessible at `/loja`.

### Description
- Add a public route `get 'loja'` mapped to `Public::StoreController#show` to serve the storefront.
- Create `Public::StoreController` with `layout 'store'` and add a lightweight `store` layout that includes the portal JS pack.
- Implement the storefront view at `app/views/public/store/show.html.erb` with Tailwind-based sections for hero, collection, services, atelier, CTA and footer driven by I18n keys.
- Add localized content under `public_store` to `config/locales/en.yml` to populate texts, product lists, highlights and testimonials.

### Testing
- No automated test suite was executed for this change.
- A manual attempt to start the app with `bin/rails server -p 3000 -b 0.0.0.0` failed due to a Ruby version mismatch (system Ruby `3.2.3` vs Gemfile-specified `3.4.4`), so no runtime smoke test was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968511941e48325bbd15fafe050307e)